### PR TITLE
refactor(module): move `mjs` files from `src` to `module` directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Run tests
         run: npm run test:ci
 
+      - name: Run module tests
+        run: npm run test:module
+
       - name: Codecov
         uses: codecov/codecov-action@v3
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,5 @@
 
 npm run lint:tsc
 npm run test:ci
+npm run test:module
 npx lint-staged

--- a/__tests__/__snapshots__/index.test.ts.snap
+++ b/__tests__/__snapshots__/index.test.ts.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`digest hashes message with algorithm SHA-1 1`] = `"da39a3ee5e6b4b0d3255bfef95601890afd80709"`;
-
-exports[`digest hashes message with algorithm SHA-256 1`] = `"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`;
-
-exports[`digest hashes message with algorithm SHA-384 1`] = `"38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"`;
-
-exports[`digest hashes message with algorithm SHA-512 1`] = `"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"`;

--- a/module/browser.mjs
+++ b/module/browser.mjs
@@ -1,0 +1,1 @@
+export { digest } from '../lib/browser.js';

--- a/module/browser.test.mjs
+++ b/module/browser.test.mjs
@@ -1,0 +1,45 @@
+import crypto from 'node:crypto';
+import { before, describe, it } from 'node:test';
+
+import assert from 'assert';
+
+describe('browser', () => {
+  let digest;
+
+  before(async () => {
+    global.crypto = crypto;
+    digest = (await import('./browser.mjs')).digest;
+  });
+
+  it('exports "digest" function', () => {
+    assert.strictEqual(typeof digest, 'function');
+  });
+
+  it('returns "SHA-1"', async () => {
+    assert.strictEqual(
+      await digest('SHA-1', ''),
+      'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+    );
+  });
+
+  it('returns "SHA-256"', async () => {
+    assert.strictEqual(
+      await digest('SHA-256', ''),
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    );
+  });
+
+  it('returns "SHA-384"', async () => {
+    assert.strictEqual(
+      await digest('SHA-384', ''),
+      '38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b'
+    );
+  });
+
+  it('returns "SHA-512"', async () => {
+    assert.strictEqual(
+      await digest('SHA-384', ''),
+      '38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b'
+    );
+  });
+});

--- a/module/browser.test.mjs
+++ b/module/browser.test.mjs
@@ -15,28 +15,28 @@ describe('browser', () => {
     assert.strictEqual(typeof digest, 'function');
   });
 
-  it('returns "SHA-1"', async () => {
+  it('hashes message with algorithm "SHA-1"', async () => {
     assert.strictEqual(
       await digest('SHA-1', ''),
       'da39a3ee5e6b4b0d3255bfef95601890afd80709'
     );
   });
 
-  it('returns "SHA-256"', async () => {
+  it('hashes message with algorithm "SHA-256"', async () => {
     assert.strictEqual(
       await digest('SHA-256', ''),
       'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
     );
   });
 
-  it('returns "SHA-384"', async () => {
+  it('hashes message with algorithm "SHA-384"', async () => {
     assert.strictEqual(
       await digest('SHA-384', ''),
       '38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b'
     );
   });
 
-  it('returns "SHA-512"', async () => {
+  it('hashes message with algorithm "SHA-512"', async () => {
     assert.strictEqual(
       await digest('SHA-384', ''),
       '38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b'

--- a/module/index.mjs
+++ b/module/index.mjs
@@ -1,0 +1,1 @@
+export { digest } from '../lib/index.js';

--- a/module/index.test.mjs
+++ b/module/index.test.mjs
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+
+import assert from 'assert';
+
+import { digest } from './index.mjs';
+
+describe('index', () => {
+  it('exports "digest" function', () => {
+    assert.strictEqual(typeof digest, 'function');
+  });
+
+  it('returns "SHA-1"', async () => {
+    assert.strictEqual(
+      await digest('SHA-1', ''),
+      'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+    );
+  });
+
+  it('returns "SHA-256"', async () => {
+    assert.strictEqual(
+      await digest('SHA-256', ''),
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    );
+  });
+
+  it('returns "SHA-384"', async () => {
+    assert.strictEqual(
+      await digest('SHA-384', ''),
+      '38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b'
+    );
+  });
+
+  it('returns "SHA-512"', async () => {
+    assert.strictEqual(
+      await digest('SHA-384', ''),
+      '38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b'
+    );
+  });
+});

--- a/module/index.test.mjs
+++ b/module/index.test.mjs
@@ -9,28 +9,28 @@ describe('index', () => {
     assert.strictEqual(typeof digest, 'function');
   });
 
-  it('returns "SHA-1"', async () => {
+  it('hashes message with algorithm "SHA-1"', async () => {
     assert.strictEqual(
       await digest('SHA-1', ''),
       'da39a3ee5e6b4b0d3255bfef95601890afd80709'
     );
   });
 
-  it('returns "SHA-256"', async () => {
+  it('hashes message with algorithm "SHA-256"', async () => {
     assert.strictEqual(
       await digest('SHA-256', ''),
       'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
     );
   });
 
-  it('returns "SHA-384"', async () => {
+  it('hashes message with algorithm "SHA-384"', async () => {
     assert.strictEqual(
       await digest('SHA-384', ''),
       '38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b'
     );
   });
 
-  it('returns "SHA-512"', async () => {
+  it('hashes message with algorithm "SHA-512"', async () => {
     assert.strictEqual(
       await digest('SHA-384', ''),
       '38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b'

--- a/package.json
+++ b/package.json
@@ -5,22 +5,22 @@
   "author": "Mark <mark@remarkablemark.org>",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "module": "lib/index.mjs",
+  "module": "module/index.mjs",
   "exports": {
     "types": "./lib/index.d.ts",
-    "import": "./lib/index.mjs",
+    "import": "./module/index.mjs",
     "require": "./lib/index.js"
   },
   "browser": {
     "./lib/index.js": "./lib/browser.js",
-    "./lib/index.mjs": "./lib/browser.mjs"
+    "./module/index.mjs": "./module/browser.mjs"
   },
   "scripts": {
-    "build": "tsc && cp src/*.mjs lib",
+    "build": "tsc",
     "build:watch": "tsc --watch",
     "clean": "rm -rf coverage docs lib",
     "docs": "typedoc",
-    "lint": "eslint --ignore-path .gitignore --ext .js,.ts,.tsx .",
+    "lint": "eslint --ignore-path .gitignore --ext .js,.mjs,.ts .",
     "lint:fix": "npm run lint -- --fix",
     "lint:tsc": "tsc --noEmit",
     "postinstall": "husky install",
@@ -28,6 +28,7 @@
     "prepublishOnly": "pinst --disable && npm run lint && npm run lint:tsc && npm run test:ci && npm run clean && npm run build",
     "test": "jest",
     "test:ci": "CI=true jest --ci --colors --coverage",
+    "test:module": "npm run build && node --test module",
     "test:watch": "jest --watch"
   },
   "repository": {
@@ -61,7 +62,8 @@
     "typescript": "5.1.3"
   },
   "files": [
-    "lib/"
+    "lib/",
+    "module/"
   ],
   "license": "MIT"
 }

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`digest hashes message with algorithm "SHA-1" 1`] = `"da39a3ee5e6b4b0d3255bfef95601890afd80709"`;
+
+exports[`digest hashes message with algorithm "SHA-256" 1`] = `"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"`;
+
+exports[`digest hashes message with algorithm "SHA-384" 1`] = `"38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"`;
+
+exports[`digest hashes message with algorithm "SHA-512" 1`] = `"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"`;

--- a/src/browser.mjs
+++ b/src/browser.mjs
@@ -1,1 +1,0 @@
-export { digest } from './browser.js';

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,1 +1,0 @@
-export { digest } from './index.js';

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,8 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import { digest } from '../src/index.ts';
+import { digest } from './index';
 
 describe('digest', () => {
   it.each(['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'] as const)(
-    'hashes message with algorithm %s',
+    'hashes message with algorithm "%s"',
     async (algorithm) => {
       expect(await digest(algorithm, '')).toMatchSnapshot();
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,6 @@
     "strict": true,
     "outDir": "lib"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["node_modules", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

refactor(module): move mjs files from src to module directory

Release-As: 1.0.2

## What is the current behavior?

- `.mjs` files inside of `src` directory
- tests inside of `__tests__` directory

## What is the new behavior?

- `.mjs` files inside of `module` directory
- tests colocated

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation